### PR TITLE
Fix startup issues in Debian 10

### DIFF
--- a/debian/lernstick-config.lernstick-textmode.service
+++ b/debian/lernstick-config.lernstick-textmode.service
@@ -1,0 +1,12 @@
+[Unit]
+ConditionKernelCommandLine=desktop=no
+Description=Service for handling plymouth in textmode
+After=plymouth-quit.service
+Wants=plymouth-quit.service 
+
+[Service]
+Type=oneshot
+ExecStart=/bin/chvt 2
+
+[Install]
+WantedBy=getty.target

--- a/debian/lernstick-config.postinst
+++ b/debian/lernstick-config.postinst
@@ -12,6 +12,9 @@ case  "${1}" in
             dpkg-divert --package live-config --remove --rename ${ANACRON}
             rm ${STATEFILE}
         fi
+	# Enable gdm and sddm service based on preset
+	systemctl preset gdm
+	systemctl preset sddm
 
         ;;
 

--- a/debian/rules
+++ b/debian/rules
@@ -17,4 +17,4 @@ override_dh_systemd_enable:
 	dh_systemd_enable --name=lernstick-user-config
 	dh_systemd_enable --name=lernstick-user-setup
 	dh_systemd_enable --name=lernstick-xserver-xorg
-
+	dh_systemd_enable --name=lernstick-textmode

--- a/debian/rules
+++ b/debian/rules
@@ -17,3 +17,4 @@ override_dh_systemd_enable:
 	dh_systemd_enable --name=lernstick-user-config
 	dh_systemd_enable --name=lernstick-user-setup
 	dh_systemd_enable --name=lernstick-xserver-xorg
+

--- a/etc/systemd/system-preset/99-lernstick-config.preset
+++ b/etc/systemd/system-preset/99-lernstick-config.preset
@@ -1,0 +1,2 @@
+enable sddm.service
+enable gdm.service

--- a/etc/systemd/system/gdm.service.d/override.conf
+++ b/etc/systemd/system/gdm.service.d/override.conf
@@ -1,0 +1,10 @@
+[Unit]
+ConditionKernelCommandLine=|desktop=gnome
+ConditionKernelCommandLine=|desktop=mate
+ConditionKernelCommandLine=|desktop=cinnamon
+ConditionKernelCommandLine=|desktop=xfce
+ConditionKernelCommandLine=|desktop=lxde
+
+[Install]
+Alias=gdm.service
+WantedBy=graphical.target

--- a/etc/systemd/system/plymouth-quit-wait.service.d/override.conf
+++ b/etc/systemd/system/plymouth-quit-wait.service.d/override.conf
@@ -1,0 +1,2 @@
+[Unit]
+ConditionKernelCommandLine=!desktop=no

--- a/etc/systemd/system/sddm.service.d/override.conf
+++ b/etc/systemd/system/sddm.service.d/override.conf
@@ -1,0 +1,7 @@
+[Unit]
+ConditionKernelCommandLine=|desktop=kde
+ConditionKernelCommandLine=|desktop=enlightenment
+
+[Install]
+Alias=sddm.service
+WantedBy=graphical.target

--- a/lib/systemd/lernstick-desktop
+++ b/lib/systemd/lernstick-desktop
@@ -42,7 +42,7 @@ case "${LERNSTICK_DESKTOP}" in
 		;;
 
 	xfce)
-		_SESSION_MANAGER="/usr/bin/xfce4-session"
+		_SESSION_MANAGER="/usr/bin/startxfce4"
 		_DISPLAY_MANAGER="/usr/sbin/gdm3"
 		_SERVICE_NAME="gdm3"
 		;;
@@ -51,6 +51,8 @@ case "${LERNSTICK_DESKTOP}" in
 		_SESSION_MANAGER="/usr/bin/lxsession"
 		_DISPLAY_MANAGER="/usr/sbin/gdm3"
 		_SERVICE_NAME="gdm3"
+		# The xsession name is diffrent from our flag
+		LERNSTICK_DESKTOP="LXDE"
 		;;
 
 	enlightenment)
@@ -72,22 +74,21 @@ echo "new session manager: $_SESSION_MANAGER"
 if [ -n "${_SESSION_MANAGER}" -a "$PREVIOUS_SESSION_MANAGER" != "${_SESSION_MANAGER}" ]
 then
 	update-alternatives --set x-session-manager "${_SESSION_MANAGER}"
-	sed -i 's/XSession=.*/XSession=/g' /var/lib/AccountsService/users/user
+	sed -i "s/XSession=.*/XSession=${LERNSTICK_DESKTOP}/g" /var/lib/AccountsService/users/user
 fi
+
+# This service file is not needed and should not be there
+rm -f /etc/systemd/system/display-manager.service
 
 if ! grep -q "^${_DISPLAY_MANAGER}$" /etc/X11/default-display-manager
 then
-	# The user changed the default display manager, update its file and systemd symlink.
+	# The user changed the default display manager, update its file.
 	echo "${_DISPLAY_MANAGER}" > /etc/X11/default-display-manager
-	if [ -z "${_SERVICE_NAME}" ]
+
+	# If there is no display manager drop to shell
+	if [ -z "${_DISPLAY_MANAGER}" ]
 	then
-		rm -f /etc/systemd/system/display-manager.service
-		systemctl daemon-reload
-	else
-		ln -sf /lib/systemd/system/${_SERVICE_NAME}.service /etc/systemd/system/display-manager.service
-		# As this does not start services which should be running but aren't, we have to start the display manager as well.
-		# But don't wait for it to start as this would create a deadlock with live-config.
-		systemctl daemon-reload
-		systemctl --no-block start display-manager.service
+		systemctl --no-block isolate multi-user.target 
 	fi
 fi
+

--- a/lib/systemd/lernstick-desktop
+++ b/lib/systemd/lernstick-desktop
@@ -84,11 +84,5 @@ if ! grep -q "^${_DISPLAY_MANAGER}$" /etc/X11/default-display-manager
 then
 	# The user changed the default display manager, update its file.
 	echo "${_DISPLAY_MANAGER}" > /etc/X11/default-display-manager
-
-	# If there is no display manager drop to shell
-	if [ -z "${_DISPLAY_MANAGER}" ]
-	then
-		systemctl --no-block isolate multi-user.target 
-	fi
 fi
 


### PR DESCRIPTION
This fixes (most) startup issues in Debian 10.

I moved the handling when a display manger is started into the service files itself. 
Which makes it more robust because we don't have to reload systemd in the boot process.

GDM seems to ignore `x-session-manager` and uses `XSession` in `/var/lib/AccountsService/users/user` instead.

In textmode plymouth won't stop automatically, so I disabled the service plymouth-quit-wait in textmode and added a service that quits plymouth and switches to a tty 2 because sometimes on tty1 there is still systemd startup. 