### PR TITLE
In Debian 11 the KDE session manager moved from startkde to startplasma-x11

### DIFF
--- a/lib/systemd/lernstick-desktop
+++ b/lib/systemd/lernstick-desktop
@@ -31,7 +31,7 @@ case "${LERNSTICK_DESKTOP}" in
 	kde)
 		_DISPLAY_MANAGER="/usr/bin/sddm"
 		_DISPLAY_MANAGER_SERVICE_FILENAME="sddm"
-		_SESSION_MANAGER="/usr/bin/startkde"
+		_SESSION_MANAGER="/usr/bin/startplasma-x11"
 		_XSESSION="plasma"
 		sed -i 's/Session=.*/Session=plasma.desktop/' /etc/sddm.conf
 		;;


### PR DESCRIPTION
@ronnystandtke  this should fix that KDE does not start in Debian 11 builds